### PR TITLE
perf: to_h_keyの処理でmapを使わないように修正

### DIFF
--- a/lib/machiiro/ruby/support/core_ext/array.rb
+++ b/lib/machiiro/ruby/support/core_ext/array.rb
@@ -1,12 +1,12 @@
 class Array
   def to_h_key(key)
-    map do |e|
+    each_with_object({}) do |e, hash|
       if e.is_a?(Hash)
-        [e[key.to_sym], e]
+        hash[e[key.to_sym]] = e
       else
-        [e.send(key.to_sym), e]
+        hash[e.send(key.to_sym)] = e
       end
-    end.to_h
+    end
   end
 
   def to_h_array_key(key)

--- a/spec/machiiro/ruby/support/core_ext/array_spec.rb
+++ b/spec/machiiro/ruby/support/core_ext/array_spec.rb
@@ -4,5 +4,12 @@ RSpec.describe Array do
     hash = array.to_h_key(:id)
 
     expect(hash.keys).to eq([1, 2, 3])
+    expect(hash.values).to eq([array[0], array[1], array[2]])
+
+    test_class = Struct.new(:id, :value)
+    array = [test_class.new(1, 'test 1'), test_class.new(2, 'test 2'), test_class.new(3, 'test 3')]
+    hash = array.to_h_key(:id)
+    expect(hash.keys).to eq([1, 2, 3])
+    expect(hash.values).to eq([array[0], array[1], array[2]])
   end
 end


### PR DESCRIPTION
mapを使わずにeach_with_objectを使うように修正し、無駄なループを削減しました