### PR TITLE
refactor: EnumでOpenStructの利用をやめる

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /pkg/
 /spec/reports/
 /tmp/
+/vendor/
 
 # rspec failure tracking
 .rspec_status

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,29 +1,30 @@
 PATH
   remote: .
   specs:
-    machiiro-ruby-support (0.2.0)
+    machiiro-ruby-support (0.3.0)
       activerecord (~> 6.1)
       activesupport (~> 6.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (6.1.7.6)
-      activesupport (= 6.1.7.6)
-    activerecord (6.1.7.6)
-      activemodel (= 6.1.7.6)
-      activesupport (= 6.1.7.6)
-    activesupport (6.1.7.6)
+    activemodel (6.1.7.7)
+      activesupport (= 6.1.7.7)
+    activerecord (6.1.7.7)
+      activemodel (= 6.1.7.7)
+      activesupport (= 6.1.7.7)
+    activesupport (6.1.7.7)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
-    concurrent-ruby (1.2.2)
+    concurrent-ruby (1.2.3)
     diff-lcs (1.5.0)
+    docile (1.4.0)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    minitest (5.20.0)
+    minitest (5.22.2)
     rake (13.1.0)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
@@ -38,9 +39,15 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.3)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    zeitwerk (2.6.12)
+    zeitwerk (2.6.13)
 
 PLATFORMS
   ruby
@@ -50,6 +57,7 @@ DEPENDENCIES
   machiiro-ruby-support!
   rake (~> 13.0)
   rspec (~> 3.10.0)
+  simplecov
 
 BUNDLED WITH
    2.4.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: .
   specs:
     machiiro-ruby-support (0.3.0)
-      activerecord (~> 6.1)
-      activesupport (~> 6.1)
+      activerecord
+      activesupport
 
 GEM
   remote: https://rubygems.org/

--- a/lib/machiiro/ruby/support.rb
+++ b/lib/machiiro/ruby/support.rb
@@ -1,6 +1,7 @@
 require "machiiro/ruby/support/version"
 
 require "active_support"
+require "active_support/core_ext"
 require "active_record"
 
 Dir.glob("#{File.dirname(__FILE__)}/support/**/*.rb").each { |e| require e }

--- a/lib/machiiro/ruby/support/core_ext/string.rb
+++ b/lib/machiiro/ruby/support/core_ext/string.rb
@@ -79,7 +79,7 @@ class String
 
   def eval_erb(vars = {})
     b = OpenStruct.new(vars).instance_eval { binding }
-    ERB.new(self, nil, '-').result(b)
+    ERB.new(self, trim_mode: '-').result(b)
   end
 
   def eval_formula(vars = {})

--- a/lib/machiiro/ruby/support/core_ext/yaml.rb
+++ b/lib/machiiro/ruby/support/core_ext/yaml.rb
@@ -1,9 +1,12 @@
 module YAML
   @cache = {}
 
-  def self.load_file_in_cache(path)
+  # 外部から混入される危険性がないと分かっていて、safe_load_file ではチェックが
+  # 厳しすぎて load できない場合に use_unsafe_load: true を指定できる
+  def self.load_file_in_cache(path, use_unsafe_load: false)
+    load_method = use_unsafe_load ? :unsafe_load_file : :load_file
     yaml = @cache[path]
-    yaml = @cache[path] = YAML.load_file(path) if yaml.nil?
+    yaml = @cache[path] = YAML.send(load_method, path) if yaml.nil?
     yaml
   end
 end

--- a/lib/machiiro/ruby/support/core_ext/yaml.rb
+++ b/lib/machiiro/ruby/support/core_ext/yaml.rb
@@ -6,7 +6,7 @@ module YAML
   def self.load_file_in_cache(path, use_unsafe_load: false)
     load_method = use_unsafe_load ? :unsafe_load_file : :load_file
     yaml = @cache[path]
-    yaml = @cache[path] = YAML.send(load_method, path) if yaml.nil?
+    yaml = @cache[path] = YAML.public_send(load_method, path) if yaml.nil?
     yaml
   end
 end

--- a/lib/machiiro/ruby/support/helper/enum.rb
+++ b/lib/machiiro/ruby/support/helper/enum.rb
@@ -10,7 +10,7 @@ module MachiiroSupport
       private
 
       def generate_ivar_name(name)
-        name = name.to_s.gsub("-", "_")
+        name = name.to_s.underscore
 
         if name.end_with?('?')
           # ex) admin? -> @__admin

--- a/lib/machiiro/ruby/support/helper/enum.rb
+++ b/lib/machiiro/ruby/support/helper/enum.rb
@@ -113,7 +113,7 @@ module MachiiroSupport
       end
 
       def as_json(*)
-        @hash.as_json(only: %i[key name order lower_name])
+        @hash.as_json
       end
 
       def to_json(*)

--- a/lib/machiiro/ruby/support/helper/enum.rb
+++ b/lib/machiiro/ruby/support/helper/enum.rb
@@ -1,59 +1,43 @@
+# frozen_string_literal: true
+
 module MachiiroSupport
   module Enum
     def self.included(base)
       base.extend(ClassMethods)
     end
 
-    module ClassMethods
-      attr_reader :type, :enums, :enums_names
+    module Helper
+      private
 
-      def enums_ordinal(*_enums)
-        @type = :ordinal
-        @enums = _enums.map.with_index do |e, i|
-          hash = { key: i + 1, order: i }
-          if e.is_a?(Array)
-            hash[:name] = e.first
-            hash.merge!(e.second || {})
-          else
-            hash[:name] = e
-          end
-          hash[:lower_name] = hash[:name].downcase
-          hash = add_inquirer(_enums, e, hash)
+      def generate_ivar_name(name)
+        name = name.to_s.gsub("-", "_")
 
-          Entry.new self, hash
-        end
-        @enums_names = Hash[@enums.map { |e| [e.name, e] }]
-      end
-
-      def enums_string(*_enums)
-        @type = :string
-        @enums = _enums.map.with_index do |e, i|
-          hash = { order: i }
-          if e.is_a?(Array)
-            hash[:name] = e.first
-            hash.merge!(e.second || {})
-          else
-            hash[:name] = e
-          end
-          hash[:key] = hash[:name].to_s
-          hash[:lower_name] = hash[:name].downcase
-          hash = add_inquirer(_enums, e, hash)
-
-          Entry.new self, hash
-        end
-        @enums_names = Hash[@enums.map { |e| [e.name, e] }]
-      end
-
-      def method_missing(name, *args)
-        if !args.present? && enums_names[name]
-          enums_names[name]
+        if name.end_with?('?')
+          # ex) admin? -> @__admin
+          "@__#{name.delete_suffix('?')}"
         else
-          super
+          "@#{name}"
+        end
+      end
+    end
+
+    private_constant :Helper
+
+    module ClassMethods
+      attr_reader :type
+
+      def enums_ordinal(*enums)
+        @type = :ordinal
+        enums.map.with_index do |e, i|
+          define_entry!(enums, e, key: i + 1, order: i)
         end
       end
 
-      def respond_to_missing?(name, include_private = false)
-        enums_names.key?(name) || super
+      def enums_string(*enums)
+        @type = :string
+        enums.map.with_index do |e, i|
+          define_entry!(enums, e, order: i)
+        end
       end
 
       def ordinal?
@@ -65,8 +49,11 @@ module MachiiroSupport
       end
 
       def values
-        enums
+        @values ||= names.each_with_object([]) do |name, entries|
+          entries << public_send(name)
+        end
       end
+      alias enums values
 
       def value_of(key)
         key = key.to_i if ordinal?
@@ -79,26 +66,100 @@ module MachiiroSupport
         values.index { |v| v.key == key }
       end
 
+      def has?(name)
+        names.include?(name)
+      end
+
       private
 
-      def add_inquirer(_enums, e, hash)
-        _enums.each do |_e|
-          name = _e.is_a?(Array) ? _e.first : _e
-          hash["#{name.downcase}?".to_sym] = _e == e if name
+      def define_entry!(enums, e, order:, key: nil)
+        hash = {}
+
+        if e.is_a?(Array)
+          name = e.first
+          hash.merge!(e.second || {})
+        else
+          name = e
         end
 
-        hash
+        key ||= name.to_s
+
+        # add inquirer method of enum such as `admin?`
+        add_inquirer!(enums, e, hash)
+
+        names << name
+
+        # ex) :CONST_NAME -> "ConstName"
+        clazz_name = name.to_s.underscore.camelize
+
+        clazz = Class.new(Entry) do
+          extend Helper
+
+          hash.each do |k, v|
+            members << k # for Entry#to_h
+
+            next if method_defined?(k)
+
+            ivar = generate_ivar_name(k)
+
+            define_method(k) do
+              # set value to instance variable for Entry#to_h
+              instance_variable_set(ivar, v.respond_to?(:call) ? v.call : v)
+            end
+          end
+        end
+
+        const_set(clazz_name, clazz)
+
+        entry = clazz.new(key: key, order: order, name: name)
+
+        # prohibit to create instance of Entry
+        clazz.class_eval do
+          private_class_method :new
+        end
+
+        # define method to access Entry instance
+        define_singleton_method(name) do
+          entry
+        end
+      end
+
+      def names
+        @names ||= Set.new
+      end
+
+      def add_inquirer!(enums, e, hash)
+        enums.each do
+          name = _1.is_a?(Array) ? _1.first : _1
+          hash["#{name.downcase}?".to_sym] = _1 == e if name
+        end
       end
     end
 
     class Entry
-      def initialize(namespace, hash)
-        @namespace = namespace
-        @hash = hash
+      include Helper
+
+      class << self
+        def members
+          @members ||= [:key, :order, :name, :lower_name]
+        end
+      end
+
+      attr_reader :key, :order, :name, :lower_name
+
+      def initialize(key:, order:, name:)
+        @key = key
+        @order = order
+        @name = name
+        @lower_name = name.downcase
+      end
+
+      def [](key)
+        send key
       end
 
       def ==(other)
-        if other.is_a?(self.class)
+        if other.is_a?(Entry)
           key == other.key && order == other.order && name == other.name
         else
           false
@@ -113,7 +174,7 @@ module MachiiroSupport
       end
 
       def as_json(*)
-        @hash.as_json
+        to_h.as_json
       end
 
       def to_json(*)
@@ -121,20 +182,19 @@ module MachiiroSupport
       end
 
       def to_h
-        @hash
-      end
+        self.class.members.each_with_object({}) do |member, h|
+          ivar = generate_ivar_name(member)
 
-      def method_missing(name, *args)
-        if @hash.key?(name)
-          @hash[name]
-        else
-          super
+          h[member] =
+            if instance_variable_defined?(ivar)
+              instance_variable_get(ivar)
+            else
+              send member
+            end
         end
       end
-
-      def respond_to_missing?(name, include_private = false)
-        @hash.key?(name) || super
-      end
     end
+
+    private_constant :Entry
   end
 end

--- a/lib/machiiro/ruby/support/helper/enum.rb
+++ b/lib/machiiro/ruby/support/helper/enum.rb
@@ -197,7 +197,5 @@ module MachiiroSupport
         end
       end
     end
-
-    private_constant :Entry
   end
 end

--- a/lib/machiiro/ruby/support/helper/enum.rb
+++ b/lib/machiiro/ruby/support/helper/enum.rb
@@ -3,7 +3,7 @@
 module MachiiroSupport
   module Enum
     def self.included(base)
-      base.extend(ClassMethods)
+      base.extend ClassMethods
     end
 
     module Helper
@@ -29,14 +29,14 @@ module MachiiroSupport
       def enums_ordinal(*enums)
         @type = :ordinal
         enums.each_with_index do |e, i|
-          define_entry!(enums, e, key: i + 1, order: i)
+          define_entry! enums, e, key: i + 1, order: i
         end
       end
 
       def enums_string(*enums)
         @type = :string
         enums.each_with_index do |e, i|
-          define_entry!(enums, e, order: i)
+          define_entry! enums, e, order: i
         end
       end
 
@@ -63,7 +63,7 @@ module MachiiroSupport
       end
 
       def has?(name)
-        names.include?(name.to_sym)
+        names.include? name.to_sym
       end
 
       private
@@ -88,7 +88,7 @@ module MachiiroSupport
         key ||= name.to_s
 
         # add inquirer method of enum such as `admin?`
-        add_inquirer!(enums, e, hash)
+        add_inquirer! enums, e, hash
 
         names << name.to_sym
 
@@ -103,26 +103,24 @@ module MachiiroSupport
 
             next if method_defined?(k)
 
-            ivar = generate_ivar_name(k)
+            ivar = generate_ivar_name k
 
-            define_method(k) do
+            define_method k do
               # set value to instance variable for Entry#to_h
               instance_variable_set(ivar, v.respond_to?(:call) ? v.call : v)
             end
           end
         end
 
-        const_set(clazz_name, clazz)
+        const_set clazz_name, clazz
 
-        entry = clazz.new(key: key, order: order, name: name)
+        entry = clazz.new key: key, order: order, name: name
 
         # prohibit to create instance of Entry
-        clazz.class_eval do
-          private_class_method :new
-        end
+        clazz.private_class_method :new
 
         # define method to access Entry instance
-        define_singleton_method(name) do
+        define_singleton_method name do
           entry
         end
       end
@@ -186,16 +184,18 @@ module MachiiroSupport
 
       def to_h
         self.class.members.each_with_object({}) do |member, h|
-          ivar = generate_ivar_name(member)
+          ivar = generate_ivar_name member
 
           h[member] =
             if instance_variable_defined?(ivar)
-              instance_variable_get(ivar)
+              instance_variable_get ivar
             else
               send member
             end
         end
       end
     end
+
+    private_constant :Entry
   end
 end

--- a/lib/machiiro/ruby/support/helper/enum.rb
+++ b/lib/machiiro/ruby/support/helper/enum.rb
@@ -67,7 +67,7 @@ module MachiiroSupport
       end
 
       def has?(name)
-        names.include?(name)
+        names.include?(name.to_sym)
       end
 
       private
@@ -87,7 +87,7 @@ module MachiiroSupport
         # add inquirer method of enum such as `admin?`
         add_inquirer!(enums, e, hash)
 
-        names << name
+        names << name.to_sym
 
         # ex) :CONST_NAME -> "ConstName"
         clazz_name = name.to_s.underscore.camelize

--- a/lib/machiiro/ruby/support/helper/enum.rb
+++ b/lib/machiiro/ruby/support/helper/enum.rb
@@ -28,14 +28,14 @@ module MachiiroSupport
 
       def enums_ordinal(*enums)
         @type = :ordinal
-        enums.map.with_index do |e, i|
+        enums.each_with_index do |e, i|
           define_entry!(enums, e, key: i + 1, order: i)
         end
       end
 
       def enums_string(*enums)
         @type = :string
-        enums.map.with_index do |e, i|
+        enums.each_with_index do |e, i|
           define_entry!(enums, e, order: i)
         end
       end

--- a/lib/machiiro/ruby/support/helper/enum.rb
+++ b/lib/machiiro/ruby/support/helper/enum.rb
@@ -49,17 +49,13 @@ module MachiiroSupport
       end
 
       def values
-        @values ||= names.each_with_object([]) do |name, entries|
-          entries << public_send(name)
-        end
+        indexes.values
       end
       alias enums values
 
       def value_of(key)
         key = key.to_i if ordinal?
-        values.find do |v|
-          v.key == key
-        end
+        indexes[key]
       end
 
       def index_of(key)
@@ -71,6 +67,13 @@ module MachiiroSupport
       end
 
       private
+
+      def indexes
+        @indexes ||= names.each_with_object({}) do |name, indexes|
+          entry = public_send name
+          indexes[entry.key] = entry
+        end
+      end
 
       def define_entry!(enums, e, order:, key: nil)
         hash = {}

--- a/lib/machiiro/ruby/support/version.rb
+++ b/lib/machiiro/ruby/support/version.rb
@@ -1,3 +1,3 @@
 module MachiiroSupport
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end

--- a/lib/machiiro/ruby/support/version.rb
+++ b/lib/machiiro/ruby/support/version.rb
@@ -1,3 +1,3 @@
 module MachiiroSupport
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end

--- a/machiiro-ruby-support.gemspec
+++ b/machiiro-ruby-support.gemspec
@@ -36,4 +36,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 2.2"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.10.0"
+  spec.add_development_dependency "simplecov"
 end

--- a/machiiro-ruby-support.gemspec
+++ b/machiiro-ruby-support.gemspec
@@ -30,8 +30,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'activesupport', '~> 6.1'
-  spec.add_runtime_dependency 'activerecord', '~> 6.1'
+  spec.add_runtime_dependency 'activesupport'
+  spec.add_runtime_dependency 'activerecord'
 
   spec.add_development_dependency "bundler", "~> 2.2"
   spec.add_development_dependency "rake", "~> 13.0"

--- a/spec/machiiro/ruby/support/helper/enum_spec.rb
+++ b/spec/machiiro/ruby/support/helper/enum_spec.rb
@@ -55,9 +55,9 @@ RSpec.describe MachiiroSupport::Enum do
 
     it "`as_json` method of each enumerated type returns Hash" do
       aggregate_failures do
-        expect(enum1.AUTO.as_json).to eq({ 'key' => 1, 'order' => 0, 'name' => 'AUTO', 'lower_name' => 'auto' })
-        expect(enum1.ENTRY.as_json).to eq({ 'key' => 2, 'order' => 1, 'name' => 'ENTRY', 'lower_name' => 'entry' })
-        expect(enum1.EXIT.as_json).to eq({ 'key' => 3, 'order' => 2, 'name' => 'EXIT', 'lower_name' => 'exit' })
+        expect(enum1.AUTO.as_json).to eq({ 'key' => 1, 'order' => 0, 'name' => 'AUTO', 'lower_name' => 'auto', 'auto?' => true, 'entry?' => false, 'exit?' => false })
+        expect(enum1.ENTRY.as_json).to eq({ 'key' => 2, 'order' => 1, 'name' => 'ENTRY', 'lower_name' => 'entry', 'auto?' => false, 'entry?' => true, 'exit?' => false })
+        expect(enum1.EXIT.as_json).to eq({ 'key' => 3, 'order' => 2, 'name' => 'EXIT', 'lower_name' => 'exit', 'auto?' => false, 'entry?' => false, 'exit?' => true })
       end
     end
 

--- a/spec/machiiro/ruby/support/helper/enum_spec.rb
+++ b/spec/machiiro/ruby/support/helper/enum_spec.rb
@@ -142,16 +142,6 @@ RSpec.describe MachiiroSupport::Enum do
         end
       end
 
-      let(:enum2) do
-        Module.new do
-          include MachiiroSupport::Enum
-
-          enums_ordinal [:AUTO, label: ''],
-                        [:ENTRY, label: '入館'],
-                        [:EXIT, label: '退館']
-        end
-      end
-
       it "each enumerated type can be accessed" do
         aggregate_failures do
           expect(enum1.AUTO.key).to eq 1

--- a/spec/machiiro/ruby/support/helper/enum_spec.rb
+++ b/spec/machiiro/ruby/support/helper/enum_spec.rb
@@ -270,15 +270,6 @@ RSpec.describe MachiiroSupport::Enum do
         end
       end
 
-      let(:enum2) do
-        Module.new do
-          include MachiiroSupport::Enum
-
-          enums_string [:ADMIN, settings_key: :admin],
-                       [:FRONT, settings_key: :front]
-        end
-      end
-
       it "each enumerated type can be accessed" do
         aggregate_failures do
           expect(enum1.ADMIN.key).to eq 'ADMIN'

--- a/spec/machiiro/ruby/support/helper/enum_spec.rb
+++ b/spec/machiiro/ruby/support/helper/enum_spec.rb
@@ -1,0 +1,299 @@
+RSpec.describe MachiiroSupport::Enum do
+  describe '.enums_ordinal' do
+    let(:enum1) do
+      Module.new do
+        include MachiiroSupport::Enum
+
+        enums_ordinal :AUTO,
+                      :ENTRY,
+                      :EXIT
+      end
+    end
+
+    let(:enum2) do
+      Module.new do
+        include MachiiroSupport::Enum
+
+        enums_ordinal :AUTO,
+                      :ENTRY,
+                      :EXIT
+      end
+    end
+
+    it "`ordinal?` method returns true" do
+      expect(enum1.ordinal?).to eq true
+    end
+
+    it "`string?` method returns false" do
+      expect(enum1.string?).to eq false
+    end
+
+    it "`values` method returns Hash including enum" do
+      expect(enum1.values).to eq [enum1.AUTO, enum1.ENTRY, enum1.EXIT]
+    end
+
+    it "`value_of` method returns enum" do
+      aggregate_failures do
+        expect(enum1.value_of(1)).to eq enum1.AUTO
+        expect(enum1.value_of(2)).to eq enum1.ENTRY
+        expect(enum1.value_of(3)).to eq enum1.EXIT
+      end
+    end
+
+    it "`index_of` method returns index number" do
+      aggregate_failures do
+        expect(enum1.index_of(1)).to eq 0
+        expect(enum1.index_of(2)).to eq 1
+        expect(enum1.index_of(3)).to eq 2
+      end
+    end
+
+    it "raises `NoMethodError` when the method is not defined" do
+      expect(enum1.respond_to?(:NOT_DEFINED)).to eq false
+      expect { enum1.NOT_DEFINED }.to raise_error(NoMethodError)
+    end
+
+    it "`as_json` method of each enumerated type returns Hash" do
+      aggregate_failures do
+        expect(enum1.AUTO.as_json).to eq({ 'key' => 1, 'order' => 0, 'name' => 'AUTO', 'lower_name' => 'auto' })
+        expect(enum1.ENTRY.as_json).to eq({ 'key' => 2, 'order' => 1, 'name' => 'ENTRY', 'lower_name' => 'entry' })
+        expect(enum1.EXIT.as_json).to eq({ 'key' => 3, 'order' => 2, 'name' => 'EXIT', 'lower_name' => 'exit' })
+      end
+    end
+
+    it "`to_json` method of each enumerated type returns JSON string" do
+      aggregate_failures do
+        expect(JSON.parse(enum1.AUTO.to_json)).to eq enum1.AUTO.as_json
+        expect(JSON.parse(enum1.ENTRY.to_json)).to eq enum1.ENTRY.as_json
+        expect(JSON.parse(enum1.EXIT.to_json)).to eq enum1.EXIT.as_json
+      end
+    end
+
+    it "`to_h` method of each enumerated type returns Hash including all attributes" do
+      aggregate_failures do
+        expect(enum1.AUTO.to_h).to eq({ key: 1, order: 0, name: :AUTO, lower_name: :auto, auto?: true, entry?: false, exit?: false })
+        expect(enum1.ENTRY.to_h).to eq({ key: 2, order: 1, name: :ENTRY, lower_name: :entry, auto?: false, entry?: true, exit?: false })
+        expect(enum1.EXIT.to_h).to eq({ key: 3, order: 2, name: :EXIT, lower_name: :exit, auto?: false, entry?: false, exit?: true })
+      end
+    end
+
+    it "raises `NoMethodError` when the method of each enumerated type is not defined" do
+      aggregate_failures do
+        expect(enum1.AUTO.respond_to?(:not_defined)).to eq false
+        expect { enum1.AUTO.not_defined }.to raise_error(NoMethodError)
+
+        expect(enum1.ENTRY.respond_to?(:not_defined)).to eq false
+        expect { enum1.ENTRY.not_defined }.to raise_error(NoMethodError)
+
+        expect(enum1.EXIT.respond_to?(:not_defined)).to eq false
+        expect { enum1.EXIT.not_defined }.to raise_error(NoMethodError)
+      end
+    end
+
+    it "each enumerated type can be accessed" do
+      aggregate_failures do
+        expect(enum1.AUTO.key).to eq 1
+        expect(enum1.AUTO.order).to eq 0
+        expect(enum1.AUTO.name).to eq :AUTO
+        expect(enum1.AUTO.instance_variable_get(:@namespace)).to eq enum1
+
+        expect(enum1.ENTRY.key).to eq 2
+        expect(enum1.ENTRY.order).to eq 1
+        expect(enum1.ENTRY.name).to eq :ENTRY
+        expect(enum1.ENTRY.instance_variable_get(:@namespace)).to eq enum1
+
+        expect(enum1.EXIT.key).to eq 3
+        expect(enum1.EXIT.order).to eq 2
+        expect(enum1.EXIT.name).to eq :EXIT
+        expect(enum1.EXIT.instance_variable_get(:@namespace)).to eq enum1
+      end
+    end
+
+    it "each enumerated type should have inquiry method" do
+      aggregate_failures do
+        expect(enum1.AUTO.auto?).to eq true
+        expect(enum1.AUTO.entry?).to eq false
+        expect(enum1.AUTO.exit?).to eq false
+
+        expect(enum1.ENTRY.auto?).to eq false
+        expect(enum1.ENTRY.entry?).to eq true
+        expect(enum1.ENTRY.exit?).to eq false
+
+        expect(enum1.EXIT.auto?).to eq false
+        expect(enum1.EXIT.entry?).to eq false
+        expect(enum1.EXIT.exit?).to eq true
+      end
+    end
+
+    it "the enumerated types of enum1 and enum2 are same" do
+      expect(enum1.AUTO == :AUTO).to eq false
+      expect(Set.new([enum1.AUTO])).to include enum2.AUTO # for hash comparison
+      expect(enum1.values).to eq enum2.values
+    end
+
+    context 'with attributes' do
+      let(:enum1) do
+        Module.new do
+          include MachiiroSupport::Enum
+
+          enums_ordinal [:AUTO, label: ''],
+                        [:ENTRY, label: '入館'],
+                        [:EXIT, label: '退館']
+        end
+      end
+
+      let(:enum2) do
+        Module.new do
+          include MachiiroSupport::Enum
+
+          enums_ordinal [:AUTO, label: ''],
+                        [:ENTRY, label: '入館'],
+                        [:EXIT, label: '退館']
+        end
+      end
+
+      it "each enumerated type can be accessed" do
+        aggregate_failures do
+          expect(enum1.AUTO.key).to eq 1
+          expect(enum1.AUTO.order).to eq 0
+          expect(enum1.AUTO.name).to eq :AUTO
+          expect(enum1.AUTO.label).to eq ''
+          expect(enum1.AUTO.instance_variable_get(:@namespace)).to eq enum1
+
+          expect(enum1.ENTRY.key).to eq 2
+          expect(enum1.ENTRY.order).to eq 1
+          expect(enum1.ENTRY.name).to eq :ENTRY
+          expect(enum1.ENTRY.label).to eq '入館'
+          expect(enum1.ENTRY.instance_variable_get(:@namespace)).to eq enum1
+
+          expect(enum1.EXIT.key).to eq 3
+          expect(enum1.EXIT.order).to eq 2
+          expect(enum1.EXIT.name).to eq :EXIT
+          expect(enum1.EXIT.label).to eq '退館'
+          expect(enum1.EXIT.instance_variable_get(:@namespace)).to eq enum1
+        end
+      end
+    end
+  end
+
+  describe '.enums_string' do
+    let(:enum1) do
+      Module.new do
+        include MachiiroSupport::Enum
+
+        enums_string :NONE,
+                     :ONLY_RESERVED,
+                     :ONLY_ATTENDED
+      end
+    end
+
+    let(:enum2) do
+      Module.new do
+        include MachiiroSupport::Enum
+
+        enums_string :NONE,
+                     :ONLY_RESERVED,
+                     :ONLY_ATTENDED
+      end
+    end
+
+    it "`ordinal?` method returns false" do
+      expect(enum1.ordinal?).to eq false
+    end
+
+    it "`string?` method returns true" do
+      expect(enum1.string?).to eq true
+    end
+
+    it "`values` method returns Hash including enum" do
+      expect(enum1.values).to eq [enum1.NONE, enum1.ONLY_RESERVED, enum1.ONLY_ATTENDED]
+    end
+
+    it "`value_of` method returns enum" do
+      expect(enum1.value_of('NONE')).to eq enum1.NONE
+      expect(enum1.value_of('ONLY_RESERVED')).to eq enum1.ONLY_RESERVED
+      expect(enum1.value_of('ONLY_ATTENDED')).to eq enum1.ONLY_ATTENDED
+    end
+
+    it "`index_of` method returns index number" do
+      expect(enum1.index_of('NONE')).to eq 0
+      expect(enum1.index_of('ONLY_RESERVED')).to eq 1
+      expect(enum1.index_of('ONLY_ATTENDED')).to eq 2
+    end
+
+    it "each enumerated type can be accessed" do
+      aggregate_failures do
+        expect(enum1.NONE.key).to eq 'NONE'
+        expect(enum1.NONE.order).to eq 0
+        expect(enum1.NONE.name).to eq :NONE
+        expect(enum1.NONE.instance_variable_get(:@namespace)).to eq enum1
+
+        expect(enum1.ONLY_RESERVED.key).to eq 'ONLY_RESERVED'
+        expect(enum1.ONLY_RESERVED.order).to eq 1
+        expect(enum1.ONLY_RESERVED.name).to eq :ONLY_RESERVED
+        expect(enum1.ONLY_RESERVED.instance_variable_get(:@namespace)).to eq enum1
+
+        expect(enum1.ONLY_ATTENDED.key).to eq 'ONLY_ATTENDED'
+        expect(enum1.ONLY_ATTENDED.order).to eq 2
+        expect(enum1.ONLY_ATTENDED.name).to eq :ONLY_ATTENDED
+        expect(enum1.ONLY_ATTENDED.instance_variable_get(:@namespace)).to eq enum1
+      end
+    end
+
+    it "enum should have inquiry method" do
+      aggregate_failures do
+        expect(enum1.NONE.none?).to eq true
+        expect(enum1.NONE.only_reserved?).to eq false
+        expect(enum1.NONE.only_attended?).to eq false
+
+        expect(enum1.ONLY_RESERVED.none?).to eq false
+        expect(enum1.ONLY_RESERVED.only_reserved?).to eq true
+        expect(enum1.ONLY_RESERVED.only_attended?).to eq false
+
+        expect(enum1.ONLY_ATTENDED.none?).to eq false
+        expect(enum1.ONLY_ATTENDED.only_reserved?).to eq false
+        expect(enum1.ONLY_ATTENDED.only_attended?).to eq true
+      end
+    end
+
+    it "the enumerated types of enum1 and enum2 are same" do
+      expect(enum1.values).to eq enum2.values
+    end
+
+    context 'with attributes' do
+      let(:enum1) do
+        Module.new do
+          include MachiiroSupport::Enum
+
+          enums_string [:ADMIN, settings_key: :admin],
+                       [:FRONT, settings_key: :front]
+        end
+      end
+
+      let(:enum2) do
+        Module.new do
+          include MachiiroSupport::Enum
+
+          enums_string [:ADMIN, settings_key: :admin],
+                       [:FRONT, settings_key: :front]
+        end
+      end
+
+      it "each enumerated type can be accessed" do
+        aggregate_failures do
+          expect(enum1.ADMIN.key).to eq 'ADMIN'
+          expect(enum1.ADMIN.order).to eq 0
+          expect(enum1.ADMIN.name).to eq :ADMIN
+          expect(enum1.ADMIN.settings_key).to eq :admin
+          expect(enum1.ADMIN.instance_variable_get(:@namespace)).to eq enum1
+
+          expect(enum1.FRONT.key).to eq 'FRONT'
+          expect(enum1.FRONT.order).to eq 1
+          expect(enum1.FRONT.name).to eq :FRONT
+          expect(enum1.FRONT.settings_key).to eq :front
+          expect(enum1.FRONT.instance_variable_get(:@namespace)).to eq enum1
+        end
+      end
+    end
+  end
+end

--- a/spec/machiiro/ruby/support/helper/enum_spec.rb
+++ b/spec/machiiro/ruby/support/helper/enum_spec.rb
@@ -277,4 +277,44 @@ RSpec.describe MachiiroSupport::Enum do
       end
     end
   end
+
+  describe 'The same method as the key in Hash is already defined' do
+    let(:enum1) do
+      Module.new do
+        include MachiiroSupport::Enum
+
+        enums_string :BLANK,
+                     :ZERO,
+                     :PRESENT
+      end
+    end
+
+    it "methods defined in enums are not prioritized, which means that `method_missing` is not called" do
+      aggregate_failures do
+        expect(enum1.BLANK.key).to eq 'BLANK'
+        expect(enum1.BLANK.order).to eq 0
+        expect(enum1.BLANK.name).to eq :BLANK
+        expect(enum1.BLANK.instance_variable_get(:@namespace)).to eq enum1
+        expect(enum1.BLANK.blank?).to eq false
+        expect(enum1.BLANK.zero?).to eq false
+        expect(enum1.BLANK.present?).to eq true
+
+        expect(enum1.ZERO.key).to eq 'ZERO'
+        expect(enum1.ZERO.order).to eq 1
+        expect(enum1.ZERO.name).to eq :ZERO
+        expect(enum1.ZERO.instance_variable_get(:@namespace)).to eq enum1
+        expect(enum1.ZERO.blank?).to eq false
+        expect(enum1.ZERO.zero?).to eq true
+        expect(enum1.ZERO.present?).to eq true
+
+        expect(enum1.PRESENT.key).to eq 'PRESENT'
+        expect(enum1.PRESENT.order).to eq 2
+        expect(enum1.PRESENT.name).to eq :PRESENT
+        expect(enum1.PRESENT.instance_variable_get(:@namespace)).to eq enum1
+        expect(enum1.PRESENT.blank?).to eq false
+        expect(enum1.PRESENT.zero?).to eq false
+        expect(enum1.PRESENT.present?).to eq true
+      end
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,10 @@
 require "bundler/setup"
+require 'simplecov'
+SimpleCov.start do
+  add_filter 'vendor/'
+  add_filter 'spec/'
+end
+
 require "machiiro/ruby/support"
 
 RSpec.configure do |config|


### PR DESCRIPTION
## 概要
- ruby3のOpenStruct非推奨に伴いEnumでの利用を廃止
    - インクルードしたモジュールに、`Enum::Entry`のサブクラスを動的に追加する
    - Enum::Entryの同値判定は、key / order / nameが一致していることとする（OpenStruct利用時と同様の挙動）
    - method_missingを撤廃（パフォーマンス観点）
    - enums_namesを撤廃
    - proc/lambdaの対応（クラスロード時の定義では要件を満たさない場合に対応）
- enum.rbのspecを追加
- simplecovを追加
- versionを0.3.0へ
- eval_erbではまだOpenStructを利用している
- コード自動生成スクリプトではエラーが発生しないことを確認済み
- values.pluck(:hoge)のように`pluck`メソッドが使えることを確認済み（`[]`メソッドを追加した）

## benchmark


| Version | Access Type | Iterations | User Time | System Time | Total Time | Real Time |
|---------|-------------|------------|-----------|-------------|------------|-----------|
| OpenStruct Version | enum access | 1000 | 0.000469 | 0.000029 | 0.000498 | 0.000497 |
| This Version | enum access | 1000 | 0.000126 | 0.000023 | 0.000149 | 0.000191 |
| OpenStruct Version | enum access | 10000 | 0.004125 | 0.000075 | 0.004200 | 0.004227 |
| This Version | enum access | 10000 | 0.001043 | 0.000003 | 0.001046 | 0.001054 |
| OpenStruct Version | enum access | 100000 | 0.032144 | 0.000998 | 0.033142 | 0.033224 |
| This Version | enum access | 100000 | 0.009313 | 0.000008 | 0.009321 | 0.009334 |
| OpenStruct Version | method access | 1000 | 0.000319 | 0.000001 | 0.000320 | 0.000319 |
| This Version | method access | 1000 | 0.000239 | 0.000002 | 0.000241 | 0.000246 |
| OpenStruct Version | method access | 10000 | 0.003319 | 0.000102 | 0.003421 | 0.003429 |
| This Version | method access | 10000 | 0.002284 | 0.000003 | 0.002287 | 0.002292 |
| OpenStruct Version | method access | 100000 | 0.028652 | 0.000209 | 0.028861 | 0.028960 |
| This Version | method access | 100000 | 0.019851 | 0.000020 | 0.019871 | 0.019947 |






