### PR TITLE
build: for bump ruby rails

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: .
   specs:
     machiiro-ruby-support (0.3.0)
-      activerecord (~> 6.1)
-      activesupport (~> 6.1)
+      activerecord
+      activesupport
 
 GEM
   remote: https://rubygems.org/

--- a/lib/machiiro/ruby/support/core_ext/string.rb
+++ b/lib/machiiro/ruby/support/core_ext/string.rb
@@ -79,7 +79,7 @@ class String
 
   def eval_erb(vars = {})
     b = OpenStruct.new(vars).instance_eval { binding }
-    ERB.new(self, nil, '-').result(b)
+    ERB.new(self, trim_mode: '-').result(b)
   end
 
   def eval_formula(vars = {})

--- a/lib/machiiro/ruby/support/core_ext/yaml.rb
+++ b/lib/machiiro/ruby/support/core_ext/yaml.rb
@@ -1,9 +1,12 @@
 module YAML
   @cache = {}
 
-  def self.load_file_in_cache(path)
+  # 外部から混入される危険性がないと分かっていて、safe_load_file ではチェックが
+  # 厳しすぎて load できない場合に use_unsafe_load: true を指定できる
+  def self.load_file_in_cache(path, use_unsafe_load: false)
+    load_method = use_unsafe_load ? :unsafe_load_file : :load_file
     yaml = @cache[path]
-    yaml = @cache[path] = YAML.load_file(path) if yaml.nil?
+    yaml = @cache[path] = YAML.send(load_method, path) if yaml.nil?
     yaml
   end
 end

--- a/lib/machiiro/ruby/support/core_ext/yaml.rb
+++ b/lib/machiiro/ruby/support/core_ext/yaml.rb
@@ -6,7 +6,7 @@ module YAML
   def self.load_file_in_cache(path, use_unsafe_load: false)
     load_method = use_unsafe_load ? :unsafe_load_file : :load_file
     yaml = @cache[path]
-    yaml = @cache[path] = YAML.send(load_method, path) if yaml.nil?
+    yaml = @cache[path] = YAML.public_send(load_method, path) if yaml.nil?
     yaml
   end
 end

--- a/lib/machiiro/ruby/support/version.rb
+++ b/lib/machiiro/ruby/support/version.rb
@@ -1,3 +1,3 @@
 module MachiiroSupport
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end

--- a/machiiro-ruby-support.gemspec
+++ b/machiiro-ruby-support.gemspec
@@ -30,8 +30,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'activesupport', '~> 6.1'
-  spec.add_runtime_dependency 'activerecord', '~> 6.1'
+  spec.add_runtime_dependency 'activesupport'
+  spec.add_runtime_dependency 'activerecord'
 
   spec.add_development_dependency "bundler", "~> 2.2"
   spec.add_development_dependency "rake", "~> 13.0"


### PR DESCRIPTION
- ERB.new の deprecated オプションの除去
- YAML.unsafe_load_file を使えるようにする
- rails のバージョン依存を外す
