### PR TITLE
feat: add safely parsing period methods

### DIFF
--- a/lib/machiiro/ruby/support/core_ext/date.rb
+++ b/lib/machiiro/ruby/support/core_ext/date.rb
@@ -57,6 +57,6 @@ class Date
   # NOTE: This method does not check the format of the target.
   def self.period_format?(target)
     return false if target.nil?
-    target.to_s =~ /\A\d{6}\z/ ? true : false
+    target.to_s.match?(/\A\d{6}\z/)
   end
 end

--- a/lib/machiiro/ruby/support/core_ext/date.rb
+++ b/lib/machiiro/ruby/support/core_ext/date.rb
@@ -31,7 +31,36 @@ class Date
     Date.new(year, month, 1)
   end
 
+  # Returns the date parsed from the target, otherwise returns nil
+  # @return [Date, nil]
+  def self.parse_period_safe(period)
+    return nil unless period_parsable? period
+    parse_period period
+  end
+
+  # Returns the date parsed from the target, otherwise raises an error
+  # @raise [ArgumentError] if the target is not a string with 6 digits
+  # @return [Date]
+  def self.parse_period!(period)
+    raise ArgumentError, '"period" should can be a string with 6 digits' unless period_parsable? period
+    parse_period period
+  end
+
+  # Returns the date parsed from the target, otherwise returns a period based on the current date
+  # @return [Date]
+  def self.parse_period_or_now(period)
+    target = period_parsable?(period) ? period : Time.zone.now.to_ym_i
+    parse_period target
+  end
+
   def self.today_at_jst
     Time.now.to_jst.to_date
+  end
+
+  # Returns true if the target can be a number with 6 digits.
+  # NOTE: This method does not check the format of the target.
+  def self.period_parsable?(target)
+    return false if target.nil?
+    target.to_s =~ /\A\d{6}\z/ ? true : false
   end
 end

--- a/lib/machiiro/ruby/support/core_ext/date.rb
+++ b/lib/machiiro/ruby/support/core_ext/date.rb
@@ -31,10 +31,13 @@ class Date
     Date.new(year, month, 1)
   end
 
-  # Returns the date parsed from the target, otherwise returns nil
+  # Returns the date parsed from the target, otherwise returns the default value. Initially, the default value is nil.
+  # @example
+  #   Date.parse_period_safe('202511') # => Date.new(2025, 11, 1)
+  #   Date.parse_period_safe(nil, Date.new(2025, 5, 1)) # => Date.new(2025, 5, 1)
   # @return [Date, nil]
-  def self.parse_period_safe(period)
-    return nil unless period_parsable? period
+  def self.parse_period_safe(period, default = nil)
+    return default unless period_format? period
     parse_period period
   end
 
@@ -42,15 +45,8 @@ class Date
   # @raise [ArgumentError] if the target is not a string with 6 digits
   # @return [Date]
   def self.parse_period!(period)
-    raise ArgumentError, '"period" should can be a string with 6 digits' unless period_parsable? period
+    raise ArgumentError, '"period" should can be a string with 6 digits' unless period_format? period
     parse_period period
-  end
-
-  # Returns the date parsed from the target, otherwise returns a period based on the current date
-  # @return [Date]
-  def self.parse_period_or_now(period)
-    target = period_parsable?(period) ? period : Time.zone.now.to_ym_i
-    parse_period target
   end
 
   def self.today_at_jst
@@ -59,7 +55,7 @@ class Date
 
   # Returns true if the target can be a number with 6 digits.
   # NOTE: This method does not check the format of the target.
-  def self.period_parsable?(target)
+  def self.period_format?(target)
     return false if target.nil?
     target.to_s =~ /\A\d{6}\z/ ? true : false
   end

--- a/lib/machiiro/ruby/support/version.rb
+++ b/lib/machiiro/ruby/support/version.rb
@@ -1,3 +1,3 @@
 module MachiiroSupport
-  VERSION = "0.3.1"
+  VERSION = "0.4.0"
 end

--- a/spec/machiiro/ruby/support/core_ext/date_spec.rb
+++ b/spec/machiiro/ruby/support/core_ext/date_spec.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 RSpec.describe Date do
-  describe '#period_parsable?' do
+  describe '#period_format?' do
     [
       condition: 'valid integer', value: 202511,
       condition: 'valid string', value: '202511',
     ].each do |caze|
       context "when the date is #{caze[:condition]}" do
         it 'returns true' do
-          expect(Date.period_parsable?(caze[:value])).to be true
+          expect(Date.period_format?(caze[:value])).to be true
         end
       end
     end
@@ -24,7 +24,7 @@ RSpec.describe Date do
     ].each do |caze|
       context "when the date is #{caze[:condition]}" do
         it 'returns false' do
-          expect(Date.period_parsable?(caze[:value])).to be false
+          expect(Date.period_format?(caze[:value])).to be false
         end
       end
     end
@@ -42,6 +42,12 @@ RSpec.describe Date do
         expect(Date.parse_period_safe('20251115')).to be nil
       end
     end
+
+    context 'when the period cannot be parsed and the default value is specified' do
+      it 'returns the specified value' do
+        expect(Date.parse_period_safe('20251115', Date.new(2025, 5, 1))).to eq Date.new(2025, 5, 1)
+      end
+    end
   end
 
   describe '#parse_period!' do
@@ -54,24 +60,6 @@ RSpec.describe Date do
     context 'when the period cannot be parsed' do
       it 'raises an error' do
         expect { Date.parse_period!('2025-01-01') }.to raise_error(ArgumentError)
-      end
-    end
-  end
-
-  describe '#parse_period_or_now' do
-    context 'when the period can be parsed' do
-      it 'returns the date' do
-        expect(Date.parse_period_or_now('202511')).to eq Date.new(2025, 11, 1)
-      end
-    end
-
-    context 'when the period cannot be parsed' do
-      before do
-        travel_to Date.new(2025, 7, 7)
-      end
-
-      it 'returns a period based on the current date' do
-        expect(Date.parse_period_or_now(nil)).to eq Date.new(2025, 7, 1)
       end
     end
   end

--- a/spec/machiiro/ruby/support/core_ext/date_spec.rb
+++ b/spec/machiiro/ruby/support/core_ext/date_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+RSpec.describe Date do
+  describe '#period_parsable?' do
+    [
+      condition: 'valid integer', value: 202511,
+      condition: 'valid string', value: '202511',
+    ].each do |caze|
+      context "when the date is #{caze[:condition]}" do
+        it 'returns true' do
+          expect(Date.period_parsable?(caze[:value])).to be true
+        end
+      end
+    end
+
+    [
+      { condition: 'only year', value: '2025' },
+      { condition: 'month with empty', value: '2025 5' },
+      { condition: 'a string like a date', value: '20251010' },
+      { condition: 'nil', value: nil },
+      { condition: 'empty', value: '' },
+      { condition: 'invalid', value: 'not a number' },
+      { condition: 'a string from a Struct', value: Struct.new(:year, :month).new(2025, 11).to_s },
+    ].each do |caze|
+      context "when the date is #{caze[:condition]}" do
+        it 'returns false' do
+          expect(Date.period_parsable?(caze[:value])).to be false
+        end
+      end
+    end
+  end
+
+  describe '#parse_period_safe' do
+    context 'when the period can be parsed' do
+      it 'returns the date' do
+        expect(Date.parse_period_safe('202511')).to eq Date.new(2025, 11, 1)
+      end
+    end
+
+    context 'when the period cannot be parsed' do
+      it 'returns nil' do
+        expect(Date.parse_period_safe('20251115')).to be nil
+      end
+    end
+  end
+
+  describe '#parse_period!' do
+    context 'when the period can be parsed' do
+      it 'returns the date' do
+        expect(Date.parse_period!('202511')).to eq Date.new(2025, 11, 1)
+      end
+    end
+
+    context 'when the period cannot be parsed' do
+      it 'raises an error' do
+        expect { Date.parse_period!('2025-01-01') }.to raise_error(ArgumentError)
+      end
+    end
+  end
+
+  describe '#parse_period_or_now' do
+    context 'when the period can be parsed' do
+      it 'returns the date' do
+        expect(Date.parse_period_or_now('202511')).to eq Date.new(2025, 11, 1)
+      end
+    end
+
+    context 'when the period cannot be parsed' do
+      before do
+        travel_to Date.new(2025, 7, 7)
+      end
+
+      it 'returns a period based on the current date' do
+        expect(Date.parse_period_or_now(nil)).to eq Date.new(2025, 7, 1)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,12 @@ SimpleCov.start do
   add_filter 'spec/'
 end
 
+require 'active_support/time'
+require 'active_support/time_with_zone'
+require 'active_support/testing/time_helpers'
 require "machiiro/ruby/support"
+
+Time.zone = 'Asia/Tokyo'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
@@ -17,4 +22,6 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
+
+  config.include ActiveSupport::Testing::TimeHelpers
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,12 +5,7 @@ SimpleCov.start do
   add_filter 'spec/'
 end
 
-require 'active_support/time'
-require 'active_support/time_with_zone'
-require 'active_support/testing/time_helpers'
 require "machiiro/ruby/support"
-
-Time.zone = 'Asia/Tokyo'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
@@ -22,6 +17,4 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
-
-  config.include ActiveSupport::Testing::TimeHelpers
 end


### PR DESCRIPTION
# 概要

## 背景

hacomono本体は、リンターによって`Date#parse_period` メソッドに対して適切なエラーハンドリングすることを要求するようになりました。`Date#parse_period` メソッドを呼ぶたびにレスキューするのはやや面倒であるし、解析エラーが発生した場合のハンドリング方法が揃っている方が良いと考えました。

## メソッドと使い方

既存の `parse_period` メソッドをラップする形で3種類用意したいです。

**period_format?**

単体で使われても良いので、 `period_format?`  は公開しています。 `period_format?`のみで形式を判定して、そのまま `ValidationError` を手動でスローする使い方もサポートします。

**parse_period_safe**

`yyyymm` 形式（以下period形式）をDateに戻せないとnilを返す。第二引数を指定すると、periodに出来ないときに第二引数を返す。

**parse_period!**

`yyyymm` 形式（以下period形式）をDateに戻せないとエラーを返す。クラス内で、ターゲットが自明にperiod形式であるならば、ガード節を省略するようにして使える。

