### PR TITLE
fix: REEN-23 remove ruby2_keywords

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    machiiro-ruby-support (0.3.0)
+    machiiro-ruby-support (0.5.0)
       activerecord
       activesupport
 

--- a/lib/machiiro/ruby/support/helper/module_provider.rb
+++ b/lib/machiiro/ruby/support/helper/module_provider.rb
@@ -5,20 +5,17 @@ module MachiiroSupport
       @provider
     end
 
-    def provide(name, *args)
-      provider.provide(name, *args)
+    def provide(name, *args, **kwargs)
+      provider.provide(name, *args, **kwargs)
     end
-    ruby2_keywords(:provide) if respond_to?(:ruby2_keywords, true)
 
-    def repository(name, *args)
-      provide("#{name}_repository".to_sym, *args)
+    def repository(name, *args, **kwargs)
+      provide("#{name}_repository".to_sym, *args, **kwargs)
     end
-    ruby2_keywords(:repository) if respond_to?(:ruby2_keywords, true)
 
-    def translator(name, *args)
-      provide("#{name}_translator".to_sym, *args)
+    def translator(name, *args, **kwargs)
+      provide("#{name}_translator".to_sym, *args, **kwargs)
     end
-    ruby2_keywords(:translator) if respond_to?(:ruby2_keywords, true)
 
     class Provider
       attr_accessor :observer
@@ -27,17 +24,16 @@ module MachiiroSupport
         @modules = {}
       end
 
-      def provide(name, *args)
+      def provide(name, *args, **kwargs)
         return ModuleProxy.new(@modules[name], observer) if @modules[name].present?
 
         clazz = Object.const_get(name.to_s.split('__').map(&:camelize).join('::'))
         if clazz.present?
-          ModuleProxy.new(clazz.new(*args), observer)
+          ModuleProxy.new(clazz.new(*args, **kwargs), observer)
         else
           ModuleProxy.new(super, observer)
         end
       end
-      ruby2_keywords(:provide) if respond_to?(:ruby2_keywords, true)
 
       def register(clazz, value)
         @modules[clazz.name.demodulize.underscore.to_sym] = value
@@ -50,12 +46,11 @@ module MachiiroSupport
         @observer = observer
       end
 
-      def method_missing(name, *args, &block)
-        value = @mod.send(name, *args, &block)
+      def method_missing(name, *args, **kwargs, &block)
+        value = @mod.send(name, *args, **kwargs, &block)
         @observer.observe(@mod, name, value) if @observer.present?
         value
       end
-      ruby2_keywords(:method_missing) if respond_to?(:ruby2_keywords, true)
     end
   end
 end

--- a/lib/machiiro/ruby/support/version.rb
+++ b/lib/machiiro/ruby/support/version.rb
@@ -1,3 +1,3 @@
 module MachiiroSupport
-  VERSION = "0.4.0"
+  VERSION = "0.5.0"
 end


### PR DESCRIPTION
将来の Ruby バージョンに向けて ruby2_keywords を削除します。

https://github.com/machiiro/hacomono/pull/22626